### PR TITLE
Updated ReadMe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@ pefile-to-maec
 ==============
 v1.0.0-beta1
 
-A Python library for converting output from Ero Carrera's `pefile <https://code.google.com/p/pefile/>`_ utility to MAEC XML content.  It is currently in the BETA phase.
+A Python library for converting output from Ero Carrera's `pefile <https://code.google.com/p/pefile/>`_ utility to Malware Attribute Enumeration and Characterization (MAEC™) XML content.  It is currently in the BETA phase.
 
 pefile-to-maec uses the pefile package: "pefile is a multi-platform Python module to read and work with Portable Executable (aka PE) files. Most of the information in the PE Header is accessible, as well as all the sections, section's information and data."[1]
 
 This package consists of a module that captures the pefile output for binary files in MAEC format (``/pefile_to_maec``), and a script that uses that module (``pefile_to_maec.py``).
 
 :Source: https://github.com/MAECProject/pefile-to-maec
-:MAEC: http://maec.mitre.org
+:MAEC: https://maecproject.github.io/
 
 Dependencies
 ------------
@@ -69,5 +69,5 @@ Feedback
 --------
 
 Bug reports and feature requests are welcome and encouraged. Pull requests are
-especially appreciated. Feel free to use the issue tracker on GitHub or send an
+especially appreciated. Feel free to use the issue tracker on GitHub, join the `MAEC Community Email Discussion List <https://maec.mitre.org/community/discussionlist.html>`_, or send an
 email directly to maec@mitre.org.


### PR DESCRIPTION
Spelled-out MAEC in intro text. Replaced the link to maec.mitre.org with the maec github site link. Added a link to the community discussion list in the feedback section.
